### PR TITLE
feat: Payco 로그인 구현 완료

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/auth/controller/ExtraInfoController.java
+++ b/src/main/java/com/nhnacademy/illuwa/auth/controller/ExtraInfoController.java
@@ -1,0 +1,34 @@
+package com.nhnacademy.illuwa.auth.controller;
+
+import com.nhnacademy.illuwa.auth.dto.MemberRegisterRequest;
+import com.nhnacademy.illuwa.auth.dto.PaycoMemberUpdateRequest;
+import com.nhnacademy.illuwa.member.client.MemberServiceClient;
+import com.nhnacademy.illuwa.member.dto.MemberResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+
+@RequiredArgsConstructor
+@Controller
+public class ExtraInfoController {
+
+    private final MemberServiceClient  memberServiceClient;
+
+    @GetMapping("/extra-info")
+    public String extraInfo(Model model) {
+        MemberResponse member = memberServiceClient.getMember();
+        model.addAttribute("member", member);
+        return "auth/extra-info";
+    }
+
+    @PostMapping("/extra-info")
+    public String extraInfoSubmit(@Valid @ModelAttribute PaycoMemberUpdateRequest memberRegisterRequest) {
+        memberServiceClient.updatePaycoMember(memberRegisterRequest);
+        return "redirect:/";
+    }
+}

--- a/src/main/java/com/nhnacademy/illuwa/auth/controller/SignupController.java
+++ b/src/main/java/com/nhnacademy/illuwa/auth/controller/SignupController.java
@@ -5,11 +5,9 @@ import com.nhnacademy.illuwa.auth.dto.MemberRegisterRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @RequiredArgsConstructor
 @Controller
@@ -18,8 +16,7 @@ public class SignupController {
     private final AuthClient authClient;
 
     @GetMapping("/signup")
-    public String signup(@RequestParam(value = "isPaycoUser", defaultValue = "false") boolean isPaycoUser, Model model) {
-        model.addAttribute("isPaycoUser", isPaycoUser);
+    public String signup() {
         return "auth/signup";
     }
 

--- a/src/main/java/com/nhnacademy/illuwa/auth/dto/PaycoMemberUpdateRequest.java
+++ b/src/main/java/com/nhnacademy/illuwa/auth/dto/PaycoMemberUpdateRequest.java
@@ -1,0 +1,31 @@
+package com.nhnacademy.illuwa.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PaycoMemberUpdateRequest {
+    @NotBlank(message = "이름은 필수 입력값입니다")
+    private String name;
+    @Past
+    private LocalDate birth;
+
+    @Email(message = "유효한 이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    private String email;
+
+    @Pattern(regexp = "^010-\\d{3,4}-\\d{4}$",
+            message = "휴대폰 번호는 010으로 시작하는 11자리 숫자와 '-'로 구성되어야 합니다.")
+    private String contact;
+}

--- a/src/main/java/com/nhnacademy/illuwa/auth/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/nhnacademy/illuwa/auth/oauth/OAuth2LoginSuccessHandler.java
@@ -35,6 +35,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         JwtCookieUtil.addAccessToken(response, tokenResponse.getAccessToken(), (int) tokenResponse.getExpiresIn());
         JwtCookieUtil.addRefreshToken(response, tokenResponse.getRefreshToken(), (int) Duration.ofDays(14).toSeconds());
 
-        response.sendRedirect("/");
+        response.sendRedirect("/extra-info");
     }
 }

--- a/src/main/java/com/nhnacademy/illuwa/config/SecurityConfig.java
+++ b/src/main/java/com/nhnacademy/illuwa/config/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/login", "/signup", "/css/**", "/js/**", "/images/**", "/guest-login").permitAll()
+                        .requestMatchers("/", "/login", "/signup","/guest-login").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .requestMatchers("/mypage").authenticated()
                         .anyRequest().permitAll()

--- a/src/main/java/com/nhnacademy/illuwa/member/client/MemberServiceClient.java
+++ b/src/main/java/com/nhnacademy/illuwa/member/client/MemberServiceClient.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.illuwa.member.client;
 
+import com.nhnacademy.illuwa.auth.dto.PaycoMemberUpdateRequest;
 import com.nhnacademy.illuwa.member.dto.MemberResponse;
 import com.nhnacademy.illuwa.member.dto.MemberUpdateRequest;
 import com.nhnacademy.illuwa.member.dto.PasswordCheckRequest;
@@ -24,4 +25,7 @@ public interface MemberServiceClient {
     @PostMapping("/api/members/check-pw")
     boolean checkPassword(@RequestBody PasswordCheckRequest request);
 
+    // 페이코 회원 초기 정보 설정
+    @PutMapping("/api/members/internal/social-members")
+    void updatePaycoMember(@RequestBody PaycoMemberUpdateRequest request);
 }

--- a/src/main/java/com/nhnacademy/illuwa/member/dto/MemberResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/member/dto/MemberResponse.java
@@ -2,26 +2,27 @@ package com.nhnacademy.illuwa.member.dto;
 
 import com.nhnacademy.illuwa.member.enums.Role;
 import com.nhnacademy.illuwa.member.enums.Status;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-@Getter
-@Setter
-@AllArgsConstructor
+@Data
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class MemberResponse {
-    private Long memberId;
+    private long memberId;
+    private String paycoId;
     private String name;
+    private LocalDate birth;
     private String email;
     private Role role;
     private String contact;
     private String gradeName;
     private BigDecimal point;
     private Status status;
+    private LocalDateTime createdAt;
     private LocalDateTime lastLoginAt;
 }

--- a/src/main/java/com/nhnacademy/illuwa/member/enums/Role.java
+++ b/src/main/java/com/nhnacademy/illuwa/member/enums/Role.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Role {
-    USER("user"), ADMIN("admin");
+    USER("user"), ADMIN("admin"), PAYCO("payco");
 
     private final String value;
 

--- a/src/main/resources/templates/auth/extra-info.html
+++ b/src/main/resources/templates/auth/extra-info.html
@@ -9,21 +9,27 @@
 
 <main layout:fragment="content">
     <section class="auth-container">
-        <h2>회원가입</h2>
+        <h2>추가 정보 입력</h2>
         <div th:if="${error}" class="error-message" th:text="${error}"></div>
-        <form th:action="@{/signup}" method="post">
+        <form th:action="@{/extra-info}" method="post">
             <div class="form-group">
                 <label for="name">이름</label>
                 <input type="text"
                        id="name"
                        name="name"
                        placeholder="이름을 입력하세요."
+                       th:value="${member.name}"
+                       th:readonly="${member.name != '페이코 유저'}"
                        required>
             </div>
 
             <div class="form-group">
                 <label for="birth">생일</label>
-                <input type="date" id="birth" name="birth" required> </div>
+                <input type="date"
+                       id="birth"
+                       name="birth"
+                       th:value="${member.birth}"
+                       required> </div>
 
             <div class="form-group">
                 <label for="email">이메일</label>
@@ -31,26 +37,8 @@
                        id="email"
                        name="email"
                        placeholder="이메일을 입력하세요."
+                       th:value="${member.email}"
                        required>
-            </div>
-
-            <div class="form-group">
-                <label for="password">비밀번호</label>
-                <div class="input-with-tooltip">
-                    <input type="password"
-                           id="password"
-                           name="password"
-                           placeholder="비밀번호를 입력하세요."
-                           required>
-                    <span class="tooltip-icon" data-tooltip-target="password-tooltip">?</span>
-                    <div id="password-tooltip" class="tooltip-content">
-                        <p><strong>비밀번호 조건:</strong></p>
-                        <ul>
-                            <li>영문 대소문자, 숫자, 특수문자(!@#$%^&*)를 1개 이상 포함</li>
-                            <li>8자 이상 20자 이하</li>
-                        </ul>
-                    </div>
-                </div>
             </div>
 
             <div class="form-group">
@@ -58,6 +46,8 @@
                 <input type="text"
                        id="contact"
                        name="contact"
+                       th:value="${member.contact}"
+                       th:readonly="${member.contact != '010-0000-0000'}"
                        placeholder="-를 포함한 전화번호를 입력하세요."
                        required>
             </div>


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
- Payco 최초 로그인 시 추가 정보 기입란으로 이동합니다.
- 페이코로부터 받아온 정보를 html 에 표시하되, 사용자에게 입력을 받도록 합니다.
- 추가로, Payco 로그인 사용자가 추가 정보를 기입하지 않고, 다른 서비스를 이용하려 할 시 예외 처리나, 인가 처리 고려해보겠습니다.

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #
