### PR TITLE
feat: 포인트정책 구현 완료

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/member/enums/Role.java
+++ b/src/main/java/com/nhnacademy/illuwa/member/enums/Role.java
@@ -1,29 +1,5 @@
 package com.nhnacademy.illuwa.member.enums;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
-
 public enum Role {
-    USER("user"), ADMIN("admin"), PAYCO("payco");
-
-    private final String value;
-
-    Role(String value) {
-        this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-        return value;
-    }
-
-    @JsonCreator
-    public static Role from(String value) {
-        for (Role role : values()) {
-            if (role.value.equalsIgnoreCase(value)) {
-                return role;
-            }
-        }
-        throw new IllegalArgumentException("Unknown role: " + value);
-    }
+    USER, ADMIN, PAYCO
 }

--- a/src/main/java/com/nhnacademy/illuwa/pointpolicy/controller/AdminPointPolicyController.java
+++ b/src/main/java/com/nhnacademy/illuwa/pointpolicy/controller/AdminPointPolicyController.java
@@ -38,8 +38,12 @@ public class AdminPointPolicyController {
 
     @GetMapping("/{policyKey}/update")
     public String showUpdateForm(@PathVariable String policyKey, Model model) {
-        model.addAttribute("request", adminPointPolicyService.prepareUpdateForm(policyKey));
+        PointPolicyUpdateRequest request = adminPointPolicyService.prepareUpdateForm(policyKey);
+        String displayView = adminPointPolicyService.getDisplayView(policyKey);
+
+        model.addAttribute("request", request);
         model.addAttribute("policyKey", policyKey);
+        model.addAttribute("displayView", displayView);
         model.addAttribute("mode", "edit");
         return "admin/policy/point_policy_form";
     }

--- a/src/main/java/com/nhnacademy/illuwa/pointpolicy/dto/PointPolicyResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/pointpolicy/dto/PointPolicyResponse.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.text.NumberFormat;
 
 @Data
 @NoArgsConstructor
@@ -21,5 +22,15 @@ public class PointPolicyResponse {
     private PointValueType valueType;
 
     private String description;
+
+    public String getDisplayValue() {
+        if (this.valueType == PointValueType.RATE) {
+            return this.value.multiply(BigDecimal.valueOf(100))
+                    .stripTrailingZeros()
+                    .toPlainString() + "%";
+        } else {
+            return NumberFormat.getInstance().format(this.value) + "P";
+        }
+    }
 
 }

--- a/src/main/resources/static/css/page/_point_history.css
+++ b/src/main/resources/static/css/page/_point_history.css
@@ -1,0 +1,90 @@
+/* _point_history.css */
+
+.main-content {
+    max-width: 960px;
+    margin: 3rem auto;
+    padding: 2rem;
+    background: #fff;
+    border-radius: 1.5rem;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.05);
+    font-family: 'Nunito', sans-serif;
+}
+
+h1 {
+    text-align: center;
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    color: #4a148c; /* 진보라 */
+}
+
+.current-point {
+    text-align: center;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #6a1b9a;
+    margin-bottom: 2rem;
+}
+
+.point-tabs {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.point-tab {
+    font-size: 1rem;
+    padding: 0.6rem 1.8rem;
+    border-radius: 999px;
+    border: none;
+    cursor: pointer;
+    font-weight: 600;
+    background: linear-gradient(135deg, #90caf9, #ce93d8); /* 연한 파랑~보라 */
+    color: #283593;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+.point-tab:hover {
+    transform: translateY(-2px);
+    background: linear-gradient(135deg, #64b5f6, #ba68c8); /* 진한 파랑~보라 */
+}
+
+.point-tab.active {
+    background: linear-gradient(135deg, #42a5f5, #ab47bc); /* 활성화 시 강조 */
+    color: white;
+    box-shadow: 0 6px 15px rgba(171, 71, 188, 0.4);
+}
+
+/* 테이블 스타일 */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+}
+
+thead th {
+    padding: 1rem;
+    text-align: center;
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: #333;
+    border-bottom: 2px solid #ddd;
+    background-color: transparent;
+}
+
+tbody td {
+    text-align: center;
+    padding: 1rem;
+    border-bottom: 1px solid #eee;
+}
+
+tr.적립 td {
+    color: #2e7d32; /* 초록 */
+    font-weight: 600;
+}
+
+tr.차감 td {
+    color: #c62828; /* 빨강 */
+    font-weight: 600;
+}

--- a/src/main/resources/templates/admin/policy/point_policy_form.html
+++ b/src/main/resources/templates/admin/policy/point_policy_form.html
@@ -25,7 +25,7 @@
                class="form-control" placeholder="정책코드 입력" required />
       </div>
 
-      <!-- 수정/상세 모드일 때만 readonly 표시 -->
+      <!-- 수정 모드일 때만 readonly 표시 -->
       <div th:if="${mode != 'new'}" class="form-group" style="margin-bottom: 15px;">
         <label>정책 코드 (policyKey)</label>
         <input type="text" th:value="${policyKey}" readonly class="form-control"
@@ -35,30 +35,25 @@
       <div class="form-group" th:if="${mode == 'edit'}">
         <label for="statusSwitch">상태</label>
         <div style="display: flex; align-items: center; gap: 10px; margin-top: 8px;">
-          <label class="toggle-switch">
+          <label class="toggle-switch" style="display: flex; align-items: center; gap: 10px;">
             <input type="checkbox" id="statusSwitch" name="active"
-                   th:checked="${request.status.name() == 'ACTIVE'}" th:disabled="${mode == 'view'}"/>
+                   th:checked="${request.status.name() == 'ACTIVE'}"
+                   th:disabled="${mode == 'view'}" />
             <span class="slider round"></span>
           </label>
-          <span th:text="${request.status.name() == 'ACTIVE' ? '활성화됨' : '비활성화됨'}" class="status-text"></span>
+          <span id="statusText" class="status-text"></span>
+          <input type="hidden" name="status" id="statusValue" th:value="${request.status.name()}" />
         </div>
       </div>
 
       <!-- 적립 값 -->
       <div class="form-group" style="margin-bottom: 15px;">
         <label>적립 값 <span th:if="${mode != 'view'}" style="color:red;">*</span></label>
-
-        <!-- 읽기 전용: 보기 모드 -->
-        <div th:if="${mode == 'view'}" class="form-control" style="background-color: #f3f4f6;">
-          <span th:text="${request.valueType.name() == 'RATE'
-              ? request.value.multiply(100).stripTrailingZeros().toPlainString() + '%'
-              : #numbers.formatDecimal(request.value, 0, 'COMMA', 2, 'POINT')}"></span>
-        </div>
-
-        <input type="number" step="0.01" th:if="${mode != 'view'}"
-               th:field="*{value}" class="form-control"
+        <input type="text"
+               name="value"
+               class="form-control"
                id="valueInput"
-               th:placeholder="${request.valueType?.name() == 'RATE' ? '예: 0.5 (0.5%)' : '예: 5000 (5,000P)'}"
+               th:value="${displayView}"
                required />
       </div>
 
@@ -98,21 +93,41 @@
     </form>
 
     <script>
-      document.addEventListener('DOMContentLoaded', function () {
-        // 상태 토글
-        const toggle = document.getElementById('statusSwitch');
-        const statusText = document.querySelector('.status-text');
+      document.addEventListener('DOMContentLoaded', () => {
+        const valueInput = document.getElementById('valueInput');
 
-        if (toggle && statusText) {
-          function updateStatusText() {
-            statusText.textContent = toggle.checked ? '활성화됨' : '비활성화됨';
+        // 폼 제출 전에 displayView 문자열에서 숫자만 추출해서 변환
+        document.querySelector('form').addEventListener('submit', (e) => {
+          let val = valueInput.value;
+
+          val = val.replace(/[^\d\.]/g, ''); // 숫자와 점(.)만 남기기
+
+          // 변환된 숫자값으로 바꾸기
+          valueInput.value = val;
+        });
+      });
+
+      document.addEventListener('DOMContentLoaded', function () {
+        const toggle = document.getElementById('statusSwitch');
+        const statusValue = document.getElementById('statusValue');
+        const statusText = document.getElementById('statusText');
+
+        if (toggle && statusValue && statusText) {
+          function syncStatus() {
+            if (toggle.checked) {
+              statusValue.value = 'ACTIVE';
+              statusText.textContent = '활성화됨';
+            } else {
+              statusValue.value = 'INACTIVE';
+              statusText.textContent = '비활성화됨';
+            }
           }
 
-          updateStatusText();
-          toggle.addEventListener('change', updateStatusText);
+          syncStatus(); // 초기 상태 반영
+          toggle.addEventListener('change', syncStatus);
         }
 
-        // Placeholder 동적 변경
+      // Placeholder 동적 변경
         const valueTypeSelect = document.getElementById('valueTypeSelect');
         const valueInput = document.getElementById('valueInput');
 

--- a/src/main/resources/templates/admin/policy/point_policy_view_list.html
+++ b/src/main/resources/templates/admin/policy/point_policy_view_list.html
@@ -41,10 +41,7 @@
                         th:classappend="${policy.status.name() == 'INACTIVE'} ? 'status-inactive' : 'status-active'">
                     </td>
                     <td>
-                      <span th:text="${policy.valueType.name() == 'RATE'
-                          ? policy.value.multiply(100).stripTrailingZeros().toPlainString() + '%'
-                          : #numbers.formatDecimal(policy.value, 0, 'COMMA', 2, 'POINT')}">
-                      </span>
+                        <span th:text="${policy.displayValue}">적립값</span>
                     </td>
                     <td th:text="${#strings.equalsIgnoreCase(policy.valueType.name(), 'AMOUNT') ? '금액'
                   : (#strings.equalsIgnoreCase(policy.valueType.name(), 'RATE') ? '비율' : policy.valueType)}"></td>

--- a/src/main/resources/templates/mypage/section/point_history.html
+++ b/src/main/resources/templates/mypage/section/point_history.html
@@ -6,46 +6,51 @@
 
 <head layout:fragment="head" title="포인트 히스토리">
   <link rel="stylesheet" th:href="@{/css/main.css}" />
-  <link rel="stylesheet" th:href="@{/css/page/_address-list.css}" />
+  <link rel="stylesheet" th:href="@{/css/page/_point_history.css}" />
   <link rel="stylesheet" th:href="@{/css/component/_pagination.css}" />
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
+
 <body>
 <main layout:fragment="content">
   <section class="main-content">
-      <h1>📊 나의 포인트 히스토리</h1>
-      <div th:text="'내 포인트 ' + ${currentPoint} + ' P'"></div>
-      <!-- 탭 버튼 -->
-      <div class="point-tabs">
-        <button class="point-tab active" onclick="filterType('ALL')">전체</button>
-        <button class="point-tab" onclick="filterType('EARN')">적립</button>
-        <button class="point-tab" onclick="filterType('USE')">차감</button>
-      </div>
 
-      <!-- 포인트 히스토리 테이블 -->
-      <table id="pointHistoryTable">
-        <thead>
-        <tr>
-          <th>일시</th>
-          <th>유형</th>
-          <th>사유</th>
-          <th>금액</th>
-          <th>잔액</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr th:each="history : ${pointHistoryList}"
-            th:classappend="${history.type.name()} == 'EARN' ? '적립' : '차감'"
-            th:data-type="${history.type.name()}">
-          <td th:text="${#temporals.format(history.createdAt, 'yyyy-MM-dd HH:mm')}"></td>
-          <td th:text="${history.type}"></td>
-          <td th:text="${history.reason}"></td>
-          <td th:text="${history.amount} + ' P'">
-          <td th:text="${history.balance} + ' P'"></td>
-        </tr>
-        </tbody>
-      </table>
+    <div class="point-header">
+      <h1>📊 포인트 히스토리</h1>
+      <div class="current-point"
+           th:text="${'<' + #numbers.formatDecimal(currentPoint, 1, 'COMMA', 0, 'POINT').replaceFirst('\\.00$', '') + ' P>'}"></div>
+    </div>
+    <!-- 탭 버튼 -->
+    <div class="point-tabs">
+      <button class="point-tab active" onclick="filterType('ALL')">전체</button>
+      <button class="point-tab" onclick="filterType('EARN')">적립</button>
+      <button class="point-tab" onclick="filterType('USE')">차감</button>
+    </div>
+
+    <!-- 포인트 히스토리 테이블 -->
+    <table id="pointHistoryTable">
+      <thead>
+      <tr>
+        <th>일시</th>
+        <th>유형</th>
+        <th>사유</th>
+        <th>금액</th>
+        <th>잔액</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr th:each="history : ${pointHistoryList}"
+          th:classappend="${history.type.name()} == 'EARN' ? '적립' : '차감'"
+          th:data-type="${history.type.name()}">
+        <td th:text="${#temporals.format(history.createdAt, 'yyyy-MM-dd HH:mm')}"></td>
+        <td th:text="${history.type}"></td>
+        <td th:text="${history.reason}"></td>
+        <td th:text="${#numbers.formatDecimal(history.amount, 1, 'COMMA', 0, 'POINT').replaceFirst('\\.00$', '') + ' P'}"></td>
+        <td th:text="${#numbers.formatDecimal(history.balance, 1, 'COMMA', 0, 'POINT').replaceFirst('\\.00$', '') + ' P'}"></td>
+      </tr>
+      </tbody>
+    </table>
   </section>
 
   <script>
@@ -58,11 +63,7 @@
       const rows = document.querySelectorAll("#pointHistoryTable tbody tr");
       rows.forEach(row => {
         const rowType = row.getAttribute("data-type");
-        if (type === "ALL" || rowType === type) {
-          row.style.display = "";
-        } else {
-          row.style.display = "none";
-        }
+        row.style.display = (type === "ALL" || rowType === type) ? "" : "none";
       });
     }
   </script>


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
- 정책 값이 중간에 깨지는 거 없이 잘 변환되도록 수정
- 삭제(비활성화)한 정책은 목록에서 아래로 정렬
- 삭제된 정책은 삭제 버튼이 보이지 않음
- 수정 들어가서 활성화하면 다시 살릴 수 있음

- 백엔드에서도 활성화된 정책만 적용되도록 하였음
- 관리자가 새로 등록한 정책은 즉시 백엔드 로직 구현이 애매함
- >현재 요구사항에 정책 수정만 있는 이유

## 💬리뷰 요구사항(선택)
정수형%가 BigDecimal로 나타내면
50%는 0.5의 값이고
3%는 0.03의 값이라 
이걸 사용자에게 보여주는 형태와 서버에서 보는 형태가 다르다는 점 유의해주세요

html 보면 displayView가 사용자에게 보이는 값입니다.

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #181
