### PR TITLE
[FEAT] 도서 api 연동 

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/admin/controller/AdminBookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/admin/controller/AdminBookController.java
@@ -27,8 +27,8 @@ public class AdminBookController {
 
     @GetMapping("/manage")
     public String bookManagePage(Model model) {
-        List<BookDetailResponse> registeredBook = productServiceClient.getRegisteredBook();
-        model.addAttribute("books",registeredBook);
+        List<BookDetailWithExtraInfoResponse> registeredBooks = productServiceClient.getAllBooksWithExtraInfo();
+        model.addAttribute("books", registeredBooks);
         return "admin/book/manage";
     }
 
@@ -105,10 +105,26 @@ public class AdminBookController {
         return "redirect:/admin/book/manage";
     }
 
-    // -> 도서 수정
+    // -> 도서 수정 페이지
     @GetMapping("/edit/{id}")
-    public String updateBook(@PathVariable Long id){
-        productServiceClient.updateBook(id);
+    public String updateBookForm(@PathVariable String id, Model model) {
+        BookDetailWithExtraInfoResponse book = productServiceClient.getBookDetailWithExtraInfo(id);
+        List<CategoryResponse> categoryTree = productServiceClient.getCategoryTree();
+
+        model.addAttribute("book", book);
+        model.addAttribute("categoryTree", categoryTree);
+
+        return "admin/book/book_update";
+    }
+
+    @PostMapping("/update/{id}")
+    public String updateBook(
+            @PathVariable Long id,
+            @ModelAttribute BookUpdateRequest request
+    ) {
+        // 여기서 FeignClient 호출은 JSON으로 보내야 하므로
+        productServiceClient.updateBook(id, request);
+
         return "redirect:/admin/book/manage";
     }
 

--- a/src/main/java/com/nhnacademy/illuwa/book/client/ProductServiceClient.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/client/ProductServiceClient.java
@@ -69,11 +69,21 @@ public interface ProductServiceClient {
     List<SearchBookResponse> findBooks();
 
 
+    // 도서 삭제
     @DeleteMapping("/api/admin/books/{id}")
     void deleteBook(@PathVariable Long id);
 
-    @PatchMapping("/api/admin/books/{id}")
-    void updateBook(@PathVariable Long id);
 
+    @GetMapping("/api/admin/books/{id}/detail")
+    BookDetailWithExtraInfoResponse getBookDetailWithExtraInfo(@PathVariable String id);
+
+
+    // 도서 수정
+    @PostMapping("/api/admin/books/{id}/update")
+    void updateBook(@PathVariable("id") Long id, @RequestBody BookUpdateRequest request);
+
+
+    @GetMapping("/api/admin/books/extra_info")
+    List<BookDetailWithExtraInfoResponse> getAllBooksWithExtraInfo();
 
 }

--- a/src/main/java/com/nhnacademy/illuwa/book/dto/BookDetailResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/dto/BookDetailResponse.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 
 import java.math.BigDecimal;
 
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -20,8 +21,8 @@ public class BookDetailResponse {
     private String publisher;
     private String publishedDate;
     private String isbn;
-    private Integer regularPrice;
-    private Integer salePrice;
+    private BigDecimal regularPrice;
+    private BigDecimal salePrice;
     private boolean isGiftWrap;
     private String imgUrl;
 }

--- a/src/main/java/com/nhnacademy/illuwa/book/dto/BookDetailWithExtraInfoResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/dto/BookDetailWithExtraInfoResponse.java
@@ -1,0 +1,34 @@
+package com.nhnacademy.illuwa.book.dto;
+
+import groovy.transform.builder.Builder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookDetailWithExtraInfoResponse {
+    private Long id;
+    private String title;
+    private String contents;
+    private String description;
+    private String author;
+    private String publisher;
+    private String publishedDate;  // String 타입으로 날짜
+    private String isbn;
+    private BigDecimal regularPrice;
+    private BigDecimal salePrice;
+    private boolean giftwrap;
+    private Integer count;
+    private String imgUrl;
+    private String status;  // 예: "AVAILABLE", "UNAVAILABLE"
+    private Long categoryId;
+    private Long level1;
+    private Long level2;
+}

--- a/src/main/java/com/nhnacademy/illuwa/book/dto/BookUpdateRequest.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/dto/BookUpdateRequest.java
@@ -1,0 +1,41 @@
+package com.nhnacademy.illuwa.book.dto;
+
+import groovy.transform.builder.Builder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookUpdateRequest {
+    private Long id;
+
+    private String title;
+    private String author;
+    private String publisher;
+    private String pubDate;
+    private String isbn;
+
+    private BigDecimal regularPrice;
+    private BigDecimal salePrice;
+
+    private String description;
+    private String contents;
+
+    private String cover;
+
+    private Integer count;
+
+    private String status;
+
+    private Boolean giftwrap;
+
+    private Long level1;
+    private Long level2;
+    private Long categoryId;
+}

--- a/src/main/resources/templates/admin/book/book_update.html
+++ b/src/main/resources/templates/admin/book/book_update.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html layout:decorate="~{layout/layout}"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+
+<head layout:fragment="head">
+    <link rel="stylesheet" th:href="@{/css/main.css}" />
+    <link rel="stylesheet" th:href="@{/css/page/book/book_register.css}" />
+</head>
+
+<main layout:fragment="content">
+    <form th:action="@{|/admin/book/update/${book.id}|}" method="post" enctype="multipart/form-data">
+        <input type="hidden" name="_method" value="patch" />
+
+        <input type="hidden" name="id" th:value="${book.id}" />
+
+        <div class="mb-3">
+            <label for="title" class="form-label">제목</label>
+            <input type="text" id="title" name="title" class="form-control"
+                   th:value="${book.title != null} ? ${book.title} : ''" required />
+        </div>
+
+        <div class="mb-3">
+            <label for="author" class="form-label">저자</label>
+            <input type="text" id="author" name="author" class="form-control"
+                   th:value="${book.author != null} ? ${book.author} : ''" required />
+        </div>
+
+        <div class="mb-3">
+            <label for="publisher" class="form-label">출판사</label>
+            <input type="text" id="publisher" name="publisher" class="form-control"
+                   th:value="${book.publisher != null} ? ${book.publisher} : ''" required />
+        </div>
+
+        <div class="mb-3">
+            <label for="pubDate" class="form-label">출판일</label>
+            <input type="date" id="pubDate" name="pubDate" class="form-control"
+                   th:value="${book.publishedDate != null} ? ${book.publishedDate} : ''" required />
+        </div>
+
+        <div class="mb-3">
+            <label for="isbn" class="form-label">ISBN</label>
+            <input type="text" id="isbn" name="isbn" class="form-control"
+                   th:value="${book.isbn != null} ? ${book.isbn} : ''" required />
+        </div>
+
+        <div class="mb-3">
+            <label for="regularPrice" class="form-label">정가</label>
+            <input type="number" id="regularPrice" name="regularPrice" class="form-control"
+                   th:value="${book.regularPrice != null} ? ${book.regularPrice} : ''" required />
+        </div>
+
+        <div class="mb-3">
+            <label for="salePrice" class="form-label">판매가</label>
+            <input type="number" id="salePrice" name="salePrice" class="form-control"
+                   th:value="${book.salePrice != null} ? ${book.salePrice} : ''" required />
+        </div>
+
+        <div class="mb-3">
+            <label for="description" class="form-label">설명</label>
+            <textarea id="description" name="description" class="form-control"
+                      th:text="${book.description != null} ? ${book.description} : ''"></textarea>
+        </div>
+
+        <div class="mb-3">
+            <label for="cover" class="form-label">이미지 URL</label>
+            <input type="text" id="cover" name="cover" class="form-control"
+                   th:value="${book.imgUrl != null} ? ${book.imgUrl} : ''" />
+            <div th:if="${book.imgUrl != null and !book.imgUrl.isEmpty()}">
+                <img th:src="${book.imgUrl}" alt="도서 이미지" class="mt-2" style="max-width: 150px;"
+                     onerror="this.style.display='none'" />
+            </div>
+        </div>
+
+        <div class="mb-3">
+            <label for="count" class="form-label">등록 수량</label>
+            <input type="number" class="form-control" id="count" name="count" min="0" required
+                   th:value="${book.count != null} ? ${book.count} : 0" />
+        </div>
+
+        <div class="mb-3">
+            <label for="status" class="form-label">도서 상태</label>
+            <select id="status" name="status" class="form-select" required>
+                <option value="NORMAL" th:selected="${book.status == 'NORMAL'}">판매중</option>
+                <option value="OUT_OF_STOCK" th:selected="${book.status == 'OUT_OF_STOCK'}">품절</option>
+                <option value="DISCONTINUED" th:selected="${book.status == 'DISCONTINUED'}">판매종료</option>
+                <option value="DELETED" th:selected="${book.status == 'DELETED'}">삭제됨</option>
+            </select>
+        </div>
+
+        <input type="hidden" name="giftwrap" value="false"/>
+        <input type="checkbox" class="form-check-input" id="giftwrap" name="giftwrap" value="true"
+               th:checked="${book.giftwrap}" />
+        <label class="form-check-label" for="giftwrap">선물 포장 가능</label>
+
+        <div class="mb-3">
+            <label for="level1" class="form-label">1차 카테고리</label>
+            <select id="level1" name="level1" class="form-select">
+                <option value="">1차 카테고리 선택</option>
+                <option th:each="cat1 : ${categoryTree}"
+                        th:value="${cat1.id}"
+                        th:text="${cat1.categoryName}"
+                        th:selected="${cat1.id == book.level1}"></option>
+            </select>
+        </div>
+
+        <div class="mb-3" th:if="${#lists.size(categoryTree) > 0}">
+            <label for="level2" class="form-label">2차 카테고리</label>
+            <select id="level2" name="level2" class="form-select">
+                <option value="">2차 카테고리 선택</option>
+                <th:block th:each="cat1 : ${categoryTree}">
+                    <option th:each="cat2 : ${cat1.children}"
+                            th:value="${cat2.id}"
+                            th:text="${cat2.categoryName}"
+                            th:selected="${cat2.id == book.level2}"></option>
+                </th:block>
+            </select>
+        </div>
+
+        <div class="mb-3" th:if="${#lists.size(categoryTree) > 0}">
+            <label for="categoryId" class="form-label">3차 카테고리</label>
+            <select id="categoryId" name="categoryId" class="form-select" required>
+                <option value="">3차 카테고리 선택</option>
+                <th:block th:each="cat1 : ${categoryTree}">
+                    <th:block th:each="cat2 : ${cat1.children}">
+                        <option th:each="cat3 : ${cat2.children}"
+                                th:value="${cat3.id}"
+                                th:text="${cat3.categoryName}"
+                                th:selected="${cat3.id == book.categoryId}"></option>
+                    </th:block>
+                </th:block>
+            </select>
+        </div>
+
+        <button type="submit" class="btn btn-primary">수정</button>
+        <a th:href="@{/admin/book/manage}" class="btn btn-secondary ms-2">취소</a>
+    </form>
+</main>
+</html>

--- a/src/main/resources/templates/admin/book/manage.html
+++ b/src/main/resources/templates/admin/book/manage.html
@@ -2,7 +2,6 @@
 <html layout:decorate="~{layout/layout}"
       xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
-
 <head layout:fragment="head">
   <meta charset="UTF-8">
   <title>도서 관리 페이지</title>
@@ -11,8 +10,7 @@
 </head>
 
 <main layout:fragment="content">
-  <body>
-  <h1>📚 도서 관리 페이지</h1>
+  <h1>도서 관리 페이지</h1>
   <table>
     <thead>
     <tr>
@@ -24,13 +22,18 @@
       <th>정가</th>
       <th>판매가</th>
       <th>ISBN</th>
+      <th>재고수량</th>
+      <th>상태</th>
       <th>선물포장</th>
+      <th>카테고리</th>
       <th>관리</th>
     </tr>
     </thead>
     <tbody>
     <tr th:each="book : ${books}">
-      <td><img th:src="${book.imgUrl}" alt="도서 이미지"/></td>
+      <td>
+        <img th:src="${book.imgUrl}" alt="도서 이미지" style="max-width:100px;" />
+      </td>
       <td th:text="${book.title}">도서 제목</td>
       <td th:text="${book.author}">저자</td>
       <td th:text="${book.publisher}">출판사</td>
@@ -38,19 +41,24 @@
       <td th:text="${#numbers.formatInteger(book.regularPrice, 3, 'COMMA')} + '원'">정가</td>
       <td th:text="${#numbers.formatInteger(book.salePrice, 3, 'COMMA')} + '원'">판매가</td>
       <td th:text="${book.isbn}">ISBN</td>
-      <td th:text="${book.giftWrap ? '가능' : '불가'}">선물포장</td>
+      <td th:text="${book.count}">수량</td>
+      <td th:text="${book.status}">상태</td>
+      <td th:text="${book.giftwrap ? '가능' : '불가'}">선물포장</td>
+      <td>
+        <span th:if="${book.level1 != null}" th:text="'(1): ' + ${book.level1}"></span><br/>
+        <span th:if="${book.level2 != null}" th:text="'(2): ' + ${book.level2}"></span><br/>
+        <span th:if="${book.categoryId != null}" th:text="'(3): ' + ${book.categoryId}"></span>
+      </td>
       <td class="action-buttons">
         <a th:href="@{'/admin/book/edit/' + ${book.id}}">
           <button class="edit-btn">수정</button>
         </a>
-        <form th:action="@{'/admin/book/delete/' + ${book.id}}" method="post" th:object="${book}" style="display:inline;">
+        <form th:action="@{'/admin/book/delete/' + ${book.id}}" method="post" style="display:inline;">
           <button class="delete-btn" type="submit">삭제</button>
         </form>
       </td>
     </tr>
     </tbody>
   </table>
-  </body>
 </main>
-
 </html>

--- a/src/main/resources/templates/admin/book/manage.html
+++ b/src/main/resources/templates/admin/book/manage.html
@@ -45,9 +45,9 @@
       <td th:text="${book.status}">상태</td>
       <td th:text="${book.giftwrap ? '가능' : '불가'}">선물포장</td>
       <td>
-        <span th:if="${book.level1 != null}" th:text="'(1): ' + ${book.level1}"></span><br/>
-        <span th:if="${book.level2 != null}" th:text="'(2): ' + ${book.level2}"></span><br/>
-        <span th:if="${book.categoryId != null}" th:text="'(3): ' + ${book.categoryId}"></span>
+        <span th:if="${book.level1 != null}" th:text="'Lv1: ' + ${book.level1}"></span><br/>
+        <span th:if="${book.level2 != null}" th:text="'Lv2: ' + ${book.level2}"></span><br/>
+        <span th:if="${book.categoryId != null}" th:text="'Lv3: ' + ${book.categoryId}"></span>
       </td>
       <td class="action-buttons">
         <a th:href="@{'/admin/book/edit/' + ${book.id}}">


### PR DESCRIPTION
## 📝작업 내용
- 관리자 페이지의 카테고리 표시 네이밍 변경
- 도서 수정 API 및 페이지 추가
-  도서 가격 DTO 필드 수정
-  도서 부가 정보 Response/Request DTO 추가
-   도서 관리 페이지 개선 (수량, 상태, 카테고리)


## 💬리뷰 요구사항(선택)
- 카테고리명이 길어질 때 테이블 레이아웃이 깨지는 문제를 개선
- 카테고리 표시 네이밍 = Lv1, Lv2, Lv3(관리자 페이지)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #200 