### PR TITLE
[FEAT] 카테고리 Pagenation 구현

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/admin/controller/AdminBookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/admin/controller/AdminBookController.java
@@ -2,6 +2,7 @@ package com.nhnacademy.illuwa.admin.controller;
 
 import com.nhnacademy.illuwa.book.client.ProductServiceClient;
 import com.nhnacademy.illuwa.book.dto.*;
+import com.nhnacademy.illuwa.category.dto.CategoryResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/nhnacademy/illuwa/book/dto/BookDetailWithExtraInfoResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/dto/BookDetailWithExtraInfoResponse.java
@@ -31,4 +31,7 @@ public class BookDetailWithExtraInfoResponse {
     private Long categoryId;
     private Long level1;
     private Long level2;
+    private String level1Name;
+    private String level2Name;
+    private String categoryName;
 }

--- a/src/main/java/com/nhnacademy/illuwa/category/client/CategoryServiceClient.java
+++ b/src/main/java/com/nhnacademy/illuwa/category/client/CategoryServiceClient.java
@@ -1,9 +1,11 @@
 package com.nhnacademy.illuwa.category.client;
 
-import com.nhnacademy.illuwa.book.dto.CategoryResponse;
+import com.nhnacademy.illuwa.category.dto.CategoryListResponse;
+import com.nhnacademy.illuwa.category.dto.CategoryResponse;
 import com.nhnacademy.illuwa.category.dto.CategoryCreateRequest;
 import com.nhnacademy.illuwa.config.FeignClientConfig;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,9 +16,31 @@ public interface CategoryServiceClient {
     @GetMapping("/api/categories/tree")
     List<CategoryResponse> getCategoryTree();
 
+    @GetMapping("/api/categories")
+    List<CategoryResponse> getAllCategories();
+
+    // 카테고리 생성
     @PostMapping("/api/categories")
     void createCategory(@RequestBody CategoryCreateRequest request);
 
     @DeleteMapping("/api/categories/{id}")
     void deleteCategory(@PathVariable("id") Long id);
+
+    // 카테고리 pagination
+    @GetMapping("/api/categories/page")
+    Page<CategoryListResponse> getFlatCategories(
+            @RequestParam("page") int page,
+            @RequestParam("size") int size,
+            @RequestParam("sort") String sort
+    );
+
+    @GetMapping("/api/categories/flat")
+    List<CategoryListResponse> getFlatCategories();
+
+    @GetMapping("/api/categories/flat-paged")
+    Page<CategoryListResponse> getFlatCategoriesPaged(@RequestParam("page") int page,
+                                                      @RequestParam("size") int size,
+                                                      @RequestParam("sort") String sort);
+
+
 }

--- a/src/main/java/com/nhnacademy/illuwa/category/client/CategoryServiceClient.java
+++ b/src/main/java/com/nhnacademy/illuwa/category/client/CategoryServiceClient.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.illuwa.category.client;
 
-import com.nhnacademy.illuwa.category.dto.CategoryListResponse;
+import com.nhnacademy.illuwa.category.dto.CategoryFlatResponse;
 import com.nhnacademy.illuwa.category.dto.CategoryResponse;
 import com.nhnacademy.illuwa.category.dto.CategoryCreateRequest;
 import com.nhnacademy.illuwa.config.FeignClientConfig;
@@ -28,17 +28,17 @@ public interface CategoryServiceClient {
 
     // 카테고리 pagination
     @GetMapping("/api/categories/page")
-    Page<CategoryListResponse> getFlatCategories(
+    Page<CategoryFlatResponse> getFlatCategories(
             @RequestParam("page") int page,
             @RequestParam("size") int size,
             @RequestParam("sort") String sort
     );
 
     @GetMapping("/api/categories/flat")
-    List<CategoryListResponse> getFlatCategories();
+    List<CategoryFlatResponse> getFlatCategories();
 
-    @GetMapping("/api/categories/flat-paged")
-    Page<CategoryListResponse> getFlatCategoriesPaged(@RequestParam("page") int page,
+    @GetMapping("/api/categories/flat_paged")
+    Page<CategoryFlatResponse> getFlatCategoriesPaged(@RequestParam("page") int page,
                                                       @RequestParam("size") int size,
                                                       @RequestParam("sort") String sort);
 

--- a/src/main/java/com/nhnacademy/illuwa/category/controller/AdminCategoryController.java
+++ b/src/main/java/com/nhnacademy/illuwa/category/controller/AdminCategoryController.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.illuwa.category.controller;
 
-import com.nhnacademy.illuwa.category.dto.CategoryListResponse;
+import com.nhnacademy.illuwa.category.dto.CategoryFlatResponse;
 import com.nhnacademy.illuwa.category.client.CategoryServiceClient;
 import com.nhnacademy.illuwa.category.dto.CategoryCreateRequest;
 import lombok.RequiredArgsConstructor;
@@ -38,11 +38,11 @@ public class AdminCategoryController {
                                      @RequestParam(defaultValue = "id,asc") String sort,
                                      Model model) {
         // 페이징된 목록
-        Page<CategoryListResponse> categoryPage = categoryServiceClient.getFlatCategoriesPaged(page, size, sort);
+        Page<CategoryFlatResponse> categoryPage = categoryServiceClient.getFlatCategoriesPaged(page, size, sort);
 
         // 드롭다운
-        Page<CategoryListResponse> allPage = categoryServiceClient.getFlatCategoriesPaged(0, 100, sort);
-        List<CategoryListResponse> allCategories = allPage.getContent();
+        Page<CategoryFlatResponse> allPage = categoryServiceClient.getFlatCategoriesPaged(0, 100, sort);
+        List<CategoryFlatResponse> allCategories = allPage.getContent();
 
         model.addAttribute("categoryPage", categoryPage);
         model.addAttribute("allCategories", allCategories);

--- a/src/main/java/com/nhnacademy/illuwa/category/controller/AdminCategoryController.java
+++ b/src/main/java/com/nhnacademy/illuwa/category/controller/AdminCategoryController.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.illuwa.category.controller;
 
-import com.nhnacademy.illuwa.book.dto.CategoryResponse;
+import com.nhnacademy.illuwa.category.dto.CategoryListResponse;
 import com.nhnacademy.illuwa.category.client.CategoryServiceClient;
 import com.nhnacademy.illuwa.category.dto.CategoryCreateRequest;
 import lombok.RequiredArgsConstructor;
@@ -18,14 +18,6 @@ public class AdminCategoryController {
 
     private final CategoryServiceClient categoryServiceClient;
 
-    @GetMapping("/manage")
-    public String showCategoryManagementPage(Model model) {
-        List<CategoryResponse> categoryTree = categoryServiceClient.getCategoryTree();
-        model.addAttribute("categoryTree", categoryTree);
-
-        model.addAttribute("newCategory", new CategoryCreateRequest());
-        return "admin/category/manage";
-    }
 
     @PostMapping("/create")
     public String createCategory(@ModelAttribute CategoryCreateRequest request) {
@@ -46,11 +38,11 @@ public class AdminCategoryController {
                                      @RequestParam(defaultValue = "id,asc") String sort,
                                      Model model) {
         // 페이징된 목록
-        Page<CategoryFlatResponse> categoryPage = categoryServiceClient.getFlatCategoriesPaged(page, size, sort);
+        Page<CategoryListResponse> categoryPage = categoryServiceClient.getFlatCategoriesPaged(page, size, sort);
 
         // 드롭다운
-        Page<CategoryFlatResponse> allPage = categoryServiceClient.getFlatCategoriesPaged(0, 100, sort);
-        List<CategoryFlatResponse> allCategories = allPage.getContent();
+        Page<CategoryListResponse> allPage = categoryServiceClient.getFlatCategoriesPaged(0, 100, sort);
+        List<CategoryListResponse> allCategories = allPage.getContent();
 
         model.addAttribute("categoryPage", categoryPage);
         model.addAttribute("allCategories", allCategories);

--- a/src/main/java/com/nhnacademy/illuwa/category/controller/CateogoryController.java
+++ b/src/main/java/com/nhnacademy/illuwa/category/controller/CateogoryController.java
@@ -1,7 +1,7 @@
 package com.nhnacademy.illuwa.category.controller;
 
 import com.nhnacademy.illuwa.book.client.ProductServiceClient;
-import com.nhnacademy.illuwa.book.dto.CategoryResponse;
+import com.nhnacademy.illuwa.category.dto.CategoryResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/com/nhnacademy/illuwa/category/dto/CategoryFlatResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/category/dto/CategoryFlatResponse.java
@@ -5,7 +5,7 @@ import lombok.*;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class CategoryListResponse {
+public class CategoryFlatResponse {
     private Long id;
     private Long parentId;
     private String parentName;

--- a/src/main/java/com/nhnacademy/illuwa/category/dto/CategoryListResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/category/dto/CategoryListResponse.java
@@ -1,0 +1,14 @@
+package com.nhnacademy.illuwa.category.dto;
+
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategoryListResponse {
+    private Long id;
+    private Long parentId;
+    private String parentName;
+    private String categoryName;
+    private int depth;
+}

--- a/src/main/java/com/nhnacademy/illuwa/category/dto/CategoryResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/category/dto/CategoryResponse.java
@@ -1,4 +1,4 @@
-package com.nhnacademy.illuwa.book.dto;
+package com.nhnacademy.illuwa.category.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/resources/templates/admin/category/manage.html
+++ b/src/main/resources/templates/admin/category/manage.html
@@ -3,65 +3,75 @@
       xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
 <head>
-    <title>Category Management</title>
-    <link rel="stylesheet" th:href="@{/css/page/category/category_manage.css}" />
+  <title>카테고리 관리 페이지</title>
+  <link rel="stylesheet" th:href="@{/css/page/category/category_manage.css}" />
 </head>
 <body>
 <main layout:fragment="content">
-    <div class="container mt-4">
-        <h2 class="mb-4">카테고리 관리</h2>
+  <h1>카테고리 관리</h1>
 
-        <div class="card mb-4">
-            <div class="card-header">카테고리 생성</div>
-            <div class="card-body">
-                <form th:action="@{/admin/category/create}" th:object="${newCategory}" method="post">
-                    <div class="mb-3">
-                        <label for="categoryName" class="form-label"></label>
-                        <input placeholder="등록할 카테고리 이름" type="text" class="form-control" id="categoryName" th:field="*{categoryName}" required>
-                    </div>
-                    <div class="mb-3">
-                        <label for="parentId" class="form-label">상위 카테고리 (선택)</label>
-                        <select class="form-select" id="parentId" th:field="*{parentId}">
-                            <option value="">-- 상위 없음 (최상위 카테고리로 생성됨) --</option>
-                            <th:block th:if="${categoryTree != null}" th:replace="~{::category-options-fragment(categories=${categoryTree}, level=0)}"></th:block>
-                        </select>
-                    </div>
-                    <button type="submit" class="btn btn-primary">생성</button>
-                </form>
-            </div>
-        </div>
 
-        <div class="card">
-            <div class="card-header">카테고리 목록</div>
-            <div class="card-body category-tree-container">
-                <div th:if="${categoryTree != null}" th:replace="~{::category-tree-fragment(categories=${categoryTree})}"></div>
-                <div th:if="${categoryTree == null or #lists.isEmpty(categoryTree)}" class="text-muted">등록된 카테고리가 없습니다.</div>
-            </div>
-        </div>
+  <p style="font-size: 0.8em; color: #666; margin-bottom: 0.5em; text-align: right;">
+    레벨: 카테고리 단계 표시
+  </p>
 
+  <table>
+    <thead>
+    <tr>
+      <th>ID</th>
+      <th>카테고리명</th>
+      <th>상위 카테고리</th>
+      <th>레벨</th>
+      <th>관리</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="category : ${categoryPage.content}">
+      <td th:text="${category.id}">1</td>
+      <td th:text="${category.categoryName}">카테고리명</td>
+      <td th:text="${category.parentName != null ? category.parentName : '없음'}">상위</td>
+      <td th:text="${category.depth}">0</td>
+      <td>
+        <form th:action="@{/admin/category/delete/{id}(id=${category.id})}" method="post"
+              onsubmit="return confirm('삭제하시겠습니까?');">
+          <button type="submit">삭제</button>
+        </form>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+
+  <div class="pagination">
+    <a th:if="${categoryPage.hasPrevious()}"
+       th:href="@{|/admin/category/manage?page=${categoryPage.number - 1}&size=${categoryPage.size}&sort=id,asc|}">이전</a>
+    <span th:text="${categoryPage.number + 1}">1</span> /
+    <span th:text="${categoryPage.totalPages}">1</span>
+    <a th:if="${categoryPage.hasNext()}"
+       th:href="@{|/admin/category/manage?page=${categoryPage.number + 1}&size=${categoryPage.size}&sort=id,asc|}">다음</a>
+  </div>
+
+  <h2>카테고리 등록</h2>
+  <form th:action="@{/admin/category/create}" th:object="${newCategory}" method="post">
+    <div>
+      <label for="categoryName">카테고리명</label>
+      <input type="text" id="categoryName" th:field="*{categoryName}" placeholder="카테고리명" required/>
     </div>
-
-    <div th:fragment="category-tree-fragment(categories)">
-        <ul th:if="${not #lists.isEmpty(categories)}">
-            <li th:each="category : ${categories}">
-                <div class="category-item">
-                    <span th:text="${category.categoryName}">카테고리 이름</span>
-                    <form th:action="@{/admin/category/delete/{id}(id=${category.id})}" method="post"
-                          onsubmit="return confirm('이 카테고리를 삭제하시겠습니까?');">
-                        <button type="submit" class="btn btn-sm btn-danger">삭제</button>
-                    </form>
-                </div>
-                <div th:replace="~{::category-tree-fragment(categories=${category.children})}"></div>
-            </li>
-        </ul>
+    <div>
+      <label for="parentId">상위 카테고리 (선택)</label>
+      <select id="parentId" th:field="*{parentId}">
+        <option th:value="' '" selected>
+          선택하지 않으면 최상위 카테고리로 등록됩니다
+        </option>
+        <option th:each="c : ${allCategories}"
+                th:if="${c.depth <= 2}"
+                th:value="${c.id}"
+                th:text="${#strings.repeat('--', c.depth)} + ' ' + ${c.categoryName}">
+          카테고리명
+        </option>
+      </select>
     </div>
-
-    <th:block th:fragment="category-options-fragment(categories, level)">
-        <th:block th:each="category : ${categories}">
-            <option th:value="${category.id}" th:text="${#strings.repeat('--', level)} + ' ' + ${category.categoryName}"></option>
-            <th:block th:if="${category.children != null}" th:replace="~{::category-options-fragment(categories=${category.children}, level=${level + 1})}"></th:block>
-        </th:block>
-    </th:block>
+    <button type="submit">등록</button>
+  </form>
 </main>
 </body>
 </html>


### PR DESCRIPTION
## 📝작업 내용
- **카테고리 관리 페이지에 Pagination 도입**
  - `CategorySummaryResponse` DTO 추가 (기존 FlatResponse 역할)
  - 레벨(depth) 필드로 상위 카테고리 계층 표현

- **Feign Client API 확장**
  - 카테고리 목록 페이징 조회 API 추가
  - 카테고리 전체 목록 조회 API 분리

- **디렉토리 구조 리팩토링**
  - DTO 클래스들을 `category/dto` 폴더로 이동
  - 카테고리 관련 파일 별도 패키지로 분리 관리

- **카테고리 관리 UI 개선**
  - 페이지네이션과 드롭다운에서 레벨 표시
  - 최상위/하위 카테고리 관계 시각화

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #204 
