### PR TITLE
[FEAT] 외부 API를 통한 도서 등록 시에 MiniO Service 활용하도록 수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,12 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+            <version>8.5.7</version>
+        </dependency>
+
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/com/nhnacademy/illuwa/book/service/MinioStorageService.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/service/MinioStorageService.java
@@ -1,0 +1,83 @@
+package com.nhnacademy.illuwa.book.service;
+
+import io.minio.*;
+import io.minio.http.Method;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MinioStorageService {
+
+    private final MinioClient minioClient;
+
+    @Value("${minio.bucket}")
+    private String bucket;
+
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "webp");
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of("image/jpeg", "image/png", "image/gif", "image/webp");
+
+    @PostConstruct
+    public void init() throws Exception {
+        boolean found = minioClient.bucketExists(BucketExistsArgs.builder().bucket(bucket).build());
+        if (!found) {
+            minioClient.makeBucket(MakeBucketArgs.builder().bucket(bucket).build());
+            log.info("Bucket '{}' 생성 완료", bucket);
+        } else {
+            log.info("Bucket '{}' 이미 존재", bucket);
+        }
+    }
+
+    public String uploadBookImage(MultipartFile file) {
+        try {
+            validate(file);
+
+            String objectName = "Book/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+            minioClient.putObject(
+                    PutObjectArgs.builder()
+                            .bucket(bucket)
+                            .object(objectName)
+                            .stream(file.getInputStream(), file.getSize(), -1)
+                            .contentType(file.getContentType())
+                            .build()
+            );
+
+            String url = minioClient.getPresignedObjectUrl(
+                    GetPresignedObjectUrlArgs.builder()
+                            .method(Method.GET)
+                            .bucket(bucket)
+                            .object(objectName)
+                            .expiry(7, TimeUnit.DAYS)
+                            .build()
+            );
+
+            return url;
+        } catch (Exception e) {
+            throw new RuntimeException("이미지 업로드 실패", e);
+        }
+    }
+
+    private void validate(MultipartFile file) {
+        String ext = getExtension(file.getOriginalFilename());
+        if (!ALLOWED_EXTENSIONS.contains(ext)) {
+            throw new IllegalArgumentException("지원하지 않는 확장자: " + ext);
+        }
+        if (!ALLOWED_CONTENT_TYPES.contains(file.getContentType())) {
+            throw new IllegalArgumentException("지원하지 않는 ContentType: " + file.getContentType());
+        }
+    }
+
+    private String getExtension(String filename) {
+        return filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
+    }
+}

--- a/src/main/java/com/nhnacademy/illuwa/config/handler/MinioConfig.java
+++ b/src/main/java/com/nhnacademy/illuwa/config/handler/MinioConfig.java
@@ -1,0 +1,27 @@
+package com.nhnacademy.illuwa.config.handler;
+
+import io.minio.MinioClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MinioConfig {
+
+    @Value("${minio.url}")
+    private String url;
+
+    @Value("${minio.access-key}")
+    private String accessKey;
+
+    @Value("${minio.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public MinioClient minioClient() {
+        return MinioClient.builder()
+                .endpoint(url)
+                .credentials(accessKey, secretKey)
+                .build();
+    }
+}

--- a/src/main/resources/templates/admin/book/book_register_api.html
+++ b/src/main/resources/templates/admin/book/book_register_api.html
@@ -3,14 +3,15 @@
       xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
 
+
+
+<body>
 <head layout:fragment="head">
   <link rel="stylesheet" th:href="@{/css/main.css}" />
   <link rel="stylesheet" th:href="@{/css/page/book/book_register.css}" />
 </head>
-
-
 <main layout:fragment="content">
-  <form th:action="@{/admin/book/register_api}" method="post">
+  <form th:action="@{/admin/book/register_api}" method="post" enctype="multipart/form-data">
     <div class="mb-3">
       <label for="title" class="form-label">제목</label>
       <input type="text" id="title" name="title" class="form-control"
@@ -60,13 +61,27 @@
     </div>
 
     <div class="mb-3">
-      <label for="cover" class="form-label">이미지 URL</label>
-      <input type="text" id="cover" name="cover" class="form-control"
-             th:value="${book.cover != null} ? ${book.cover} : ''" />
-      <div th:if="${book.cover != null and !book.cover.isEmpty()}">
-        <img th:src="${book.cover}" alt="도서 이미지" class="mt-2" style="max-width: 150px;"
-             onerror="this.style.display='none'"/>
+      <label class="form-label">대표 이미지</label>
+
+      <div>
+        <img id="imagePreview"
+             th:src="${book.cover != null && !book.cover.isEmpty()} ? ${book.cover} : ''"
+             alt="대표 이미지"
+             class="mt-2"
+             style="max-width:150px; display: ${book.cover != null && !book.cover.isEmpty() ? 'block' : 'none'};"
+        />
       </div>
+
+      <input type="hidden" name="cover" th:value="${book.cover != null} ? ${book.cover} : ''" />
+
+      <input
+              type="file"
+              id="coverFile"
+              name="coverFile"
+              class="form-control mt-2"
+              accept="image/*"
+              onchange="previewImage(this)"
+      />
     </div>
 
     <div class="mb-3">
@@ -117,3 +132,23 @@
     <a th:href="@{/admin/books}" class="btn btn-secondary ms-2">취소</a>
   </form>
 </main>
+
+<section layout:fragment="scripts">
+  <script>
+    function previewImage(input) {
+      if (input.files && input.files[0]) {
+        const reader = new FileReader();
+        reader.onload = function(e) {
+          const preview = document.getElementById('imagePreview');
+          preview.src = e.target.result;
+          preview.style.display = 'block';
+        };
+        reader.readAsDataURL(input.files[0]);
+      }
+    }
+  </script>
+
+</section>
+</body>
+
+

--- a/src/main/resources/templates/admin/book/manage.html
+++ b/src/main/resources/templates/admin/book/manage.html
@@ -6,7 +6,6 @@
   <meta charset="UTF-8">
   <title>도서 관리 페이지</title>
   <link rel="stylesheet" th:href="@{/css/main.css}" />
-  <link rel="stylesheet" th:href="@{/css/page/book/book_manage.css}" />
 </head>
 
 <main layout:fragment="content">
@@ -64,10 +63,31 @@
         <form th:action="@{'/admin/book/delete/' + ${book.id}}" method="post" style="display:inline;">
           <button class="delete-btn" type="submit">삭제</button>
         </form>
+        <button type="button" onclick="openTagModal([[${book.id}]], '[[${book.title}]]')" class="tag-btn">
+          태그 등록
+        </button>
       </td>
     </tr>
     </tbody>
   </table>
+
+  <!--  태그 Modal 창-->
+  <div id="tagModal" class="modal" style="display:none;">
+    <div class="modal-content">
+      <span class="close" onclick="closeTagModal()">&times;</span>
+      <h2 id="modalTitle">태그 등록</h2>
+      <form id="tagForm" method="post">
+        <div th:each="tag : ${allTags}">
+          <label>
+            <input type="checkbox" name="tagIds" th:value="${tag.id}" />
+            <span th:text="${tag.name}"></span>
+          </label>
+          <br/>
+        </div>
+        <button type="submit">등록</button>
+      </form>
+    </div>
+  </div>
 
 
   <div class="sort-options">
@@ -81,11 +101,24 @@
        th:href="@{|/admin/book/manage?page=${bookPage.number - 1}&size=${bookPage.size}&sort=id,asc|}">이전</a>
 
     <span th:text="${bookPage.number + 1}">1</span>
-    /
+
     <span th:text="${bookPage.totalPages}">1</span>
 
     <a th:if="${bookPage.hasNext()}"
        th:href="@{|/admin/book/manage?page=${bookPage.number + 1}&size=${bookPage.size}&sort=id,asc|}">다음</a>
   </div>
 </main>
+
+<script>
+  function openTagModal(bookId, bookTitle) {
+    document.getElementById("tagModal").style.display = "block";
+    document.getElementById("modalTitle").innerText = "태그 등록 - " + bookTitle;
+    document.getElementById("tagForm").action = "/admin/book/" + bookId + "/tag";
+  }
+
+  function closeTagModal() {
+    document.getElementById("tagModal").style.display = "none";
+  }
+</script>
+
 </html>


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
- 외부 API로 받아온 도서 데이터를 등록할 때 이미지를 그대로 활용
- 관리자가 직접 등록하는 경우 `MultipartFile`을 이용하여 Minio에 업로드 후 URL을 저장
- Minio 연동을 위한 설정 및 서비스 구현

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #
