### PR TITLE
[FEAT] 도서 검색 

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/main/controller/HomeController.java
+++ b/src/main/java/com/nhnacademy/illuwa/main/controller/HomeController.java
@@ -1,8 +1,6 @@
 package com.nhnacademy.illuwa.main.controller;
 
 import com.nhnacademy.illuwa.book.client.ProductServiceClient;
-import com.nhnacademy.illuwa.book.dto.BestSellerResponse;
-import com.nhnacademy.illuwa.book.dto.SearchBookResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -21,8 +19,8 @@ public class HomeController {
     @GetMapping("/")
     public String home(Model model) {
 
-        List<BestSellerResponse> bestSeller = productServiceClient.getBestSeller();
-        model.addAttribute("bestSeller",bestSeller);
+//        List<BestSellerResponse> bestSeller = productServiceClient.getBestSeller();
+//        model.addAttribute("bestSeller",bestSeller);
         return "home";
     }
 }

--- a/src/main/java/com/nhnacademy/illuwa/search/client/BookSearchClient.java
+++ b/src/main/java/com/nhnacademy/illuwa/search/client/BookSearchClient.java
@@ -1,0 +1,13 @@
+package com.nhnacademy.illuwa.search.client;
+
+import com.nhnacademy.illuwa.search.dto.BookDocument;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "product-service", url = "${api.base-url}")
+public interface BookSearchClient {
+    @GetMapping("/api/search")
+    Page<BookDocument> searchBooks(@RequestParam String keyword, @RequestParam int page, @RequestParam int size, @RequestParam String sort);
+}

--- a/src/main/java/com/nhnacademy/illuwa/search/controller/BookSearchController.java
+++ b/src/main/java/com/nhnacademy/illuwa/search/controller/BookSearchController.java
@@ -1,0 +1,33 @@
+package com.nhnacademy.illuwa.search.controller;
+
+import com.nhnacademy.illuwa.search.dto.BookDocument;
+import com.nhnacademy.illuwa.search.service.BookSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.data.domain.Pageable;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/books")
+public class BookSearchController {
+    private final BookSearchService bookSearchService;
+
+    @GetMapping("/search")
+    public String searchBooks(
+            @RequestParam String keyword, Pageable pageable, Model model)
+    {
+
+
+        Page<BookDocument> results = bookSearchService.searchBooks(keyword, pageable);
+        model.addAttribute("books", results.getContent());
+        model.addAttribute("page", results);
+        model.addAttribute("keyword", keyword);
+        return "book/search_result";
+    }
+}

--- a/src/main/java/com/nhnacademy/illuwa/search/dto/BookDocument.java
+++ b/src/main/java/com/nhnacademy/illuwa/search/dto/BookDocument.java
@@ -1,0 +1,24 @@
+package com.nhnacademy.illuwa.search.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+//BookDocument에 대응
+public class BookDocument {
+    private Long id;
+    private String title;
+    private String description;
+    private String author;
+    private String publisher;
+    private String isbn;
+    private BigDecimal salePrice;
+    private String thumbnailUrl;
+    private LocalDate publishedDate;
+}

--- a/src/main/java/com/nhnacademy/illuwa/search/service/BookSearchService.java
+++ b/src/main/java/com/nhnacademy/illuwa/search/service/BookSearchService.java
@@ -1,0 +1,31 @@
+package com.nhnacademy.illuwa.search.service;
+
+import com.nhnacademy.illuwa.search.client.BookSearchClient;
+import com.nhnacademy.illuwa.search.dto.BookDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Pageable;
+
+
+
+@Service
+@RequiredArgsConstructor
+public class BookSearchService {
+    private final BookSearchClient bookSearchClient;
+
+    public Page<BookDocument> searchBooks(String keyword, Pageable pageable) {
+        String sortParam = pageable.getSort()
+                .stream()
+                .map(order -> order.getProperty() + "," + order.getDirection().name().toLowerCase())
+                .findFirst()
+                .orElse("id,asc"); // 기본정렬
+
+        return bookSearchClient.searchBooks(
+                keyword,
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                sortParam
+        );
+    }
+}

--- a/src/main/resources/templates/book/search_result.html
+++ b/src/main/resources/templates/book/search_result.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout}">
+<head>
+    <title>도서 검색 결과</title>
+    <link rel="stylesheet" th:href="@{/css/page/book/detail.css}" />
+</head>
+<body>
+<section layout:fragment="content">
+    <h1 th:text="'검색 결과 (' + ${page.totalElements} + '건)'"></h1>
+    <p>검색어: <span th:text="${keyword}"></span></p>
+
+        <div class="search-options">
+            <a th:href="@{|/books/search?keyword=${keyword}&sort=title.keyword,asc|}">제목순</a>
+            <a th:href="@{|/books/search?keyword=${keyword}&sort=salePrice,asc|}">낮은가격순</a>
+            <a th:href="@{|/books/search?keyword=${keyword}&sort=salePrice,desc|}">높은가격순</a>
+            <a th:href="@{|/books/search?keyword=${keyword}&sort=publishedDate,desc|}">최신순</a>
+        </div>
+
+
+    <div class="book-list">
+        <div class="book-card" th:each="book : ${books}">
+            <img th:src="${book.thumbnailUrl}" alt="도서 이미지" width="150"/>
+            <h3 th:text="${book.title}"></h3>
+            <p th:text="'저자: ' + ${book.author}"></p>
+            <p th:text="'출판사: ' + ${book.publisher}"></p>
+            <p th:text="|판매가: ${#numbers.formatInteger(book.salePrice, 3)} 원|"></p>
+            <p th:if="${book.publishedDate != null}"
+               th:text="'출간일: ' + ${#temporals.format(book.publishedDate, 'yyyy년 MM월 dd일')}"></p>
+        </div>
+    </div>
+
+    <div class="pagination">
+        <span th:if="${page.hasPrevious()}">
+            <a th:href="@{|/books/search?keyword=${keyword}&page=${page.number - 1}&size=${page.size}&sort=${#lists.arrayJoin(page.sort.iterator(), ',')}|}">이전</a>
+        </span>
+        <span th:text="${page.number + 1}"></span> / <span th:text="${page.totalPages}"></span>
+        <span th:if="${page.hasNext()}">
+            <a th:href="@{|/books/search?keyword=${keyword}&page=${page.number + 1}&size=${page.size}&sort=${#lists.arrayJoin(page.sort.iterator(), ',')}|}">다음</a>
+        </span>
+    </div>
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -29,8 +29,14 @@
 
 <div th:replace="~{layout/header :: header}"></div>
 
-<main layout:fragment="content">
 
+<main>
+    <form th:action="@{/books/search}" method="get" class="search-form">
+        <input type="text" name="keyword" placeholder="검색어를 입력하세요" required />
+        <button type="submit">검색</button>
+    </form>
+
+    <div layout:fragment="content"></div>
 </main>
 
 <div th:replace="~{layout/footer :: footer}"></div>


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
- Elasticsearch 기반 도서 검색 기능 구현
  - `BookSearchService`: 페이징, 정렬 지원
  - `BookSearchClient`: 검색 API 호출
  - `BookDocument`: Elasticsearch document DTO 작성
- 도서 검색 결과 페이지 추가
  - `search_result.html`: 검색 결과 목록 및 정렬 옵션 표시
- Layout 개선
  - 도서 검색 버튼 화면 고정 배치(`layout.html`)
- Bestseller 관련 코드 주석 처리

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #
