### PR TITLE
[FEAT] 도서 검색 이후 도서 상세페이지 이동 api 추가

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/book/client/ProductServiceClient.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/client/ProductServiceClient.java
@@ -19,6 +19,9 @@ public interface ProductServiceClient {
     @GetMapping("/api/books/{id}")
     BookDetailResponse getBookDetail(@PathVariable String id);
 
+    @GetMapping("/api/books/{id}")
+    BookDetailResponse findBookById(@PathVariable Long id);
+
     // 도서 검색 - ISBN
     @GetMapping("/api/books/isbn/{isbn}")
     BookDetailResponse findBookByIsbn(@PathVariable String isbn);

--- a/src/main/java/com/nhnacademy/illuwa/book/controller/BookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/controller/BookController.java
@@ -9,46 +9,60 @@ import com.nhnacademy.illuwa.review.dto.ReviewResponse;
 import com.nhnacademy.illuwa.review.service.ReviewService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-import java.util.List;
-import java.util.Map;
+    import java.util.List;
+    import java.util.Map;
 
-@Controller
-@RequiredArgsConstructor
-public class BookController {
-    private final BookService bookService;
-    private final ReviewService reviewService;
-    private final MemberService memberService;
+    @Controller
+    @RequiredArgsConstructor
+    @Slf4j
+    public class BookController {
+        private final BookService bookService;
+        private final ReviewService reviewService;
+        private final MemberService memberService;
 
-    @GetMapping("/user/book-info/{isbn}")
-    public String bookInfo(@PathVariable String isbn, Model model) {
-        return "book/book_info";
-    }
+        @GetMapping("/user/book-info/{isbn}")
+        public String bookInfo(@PathVariable String isbn, Model model) {
+            return "book/book_info";
+        }
 
 
-    //accessToken 검증하는 공통 서비스 이용하기
-    @GetMapping("/user/books/{isbn}")
-    public String bookDetail(@PathVariable("isbn") String isbn, Model model,
-                             HttpServletRequest request) {
-        boolean isLoginUser = JwtCookieUtil.checkAccessToken(request);
+        //accessToken 검증하는 공통 서비스 이용하기
+        @GetMapping("/user/books/{isbn}")
+        public String bookDetail(@PathVariable("isbn") String isbn, Model model,
+                                 HttpServletRequest request) {
+            boolean isLoginUser = JwtCookieUtil.checkAccessToken(request);
 
-        BookDetailResponse bookDetail = bookService.findBookByIsbn(isbn);
+            BookDetailResponse bookDetail = bookService.findBookByIsbn(isbn);
 
-        Long bookId = bookDetail.getId();
-//        PageResponse<ReviewResponse> reviewPage = reviewService.getReviewPages(bookId, 0, 5);
-//        List<Long> memberIds = reviewPage.content().stream().map(ReviewResponse::getMemberId).toList();
-//        Map<Long,String> nameMap = memberService.getNamesFromIdList(memberIds);
+            Long bookId = bookDetail.getId();
+    //        PageResponse<ReviewResponse> reviewPage = reviewService.getReviewPages(bookId, 0, 5);
+    //        List<Long> memberIds = reviewPage.content().stream().map(ReviewResponse::getMemberId).toList();
+    //        Map<Long,String> nameMap = memberService.getNamesFromIdList(memberIds);
 
-        model.addAttribute("book", bookDetail);
-//        model.addAttribute("reviewContent", reviewPage.content());
-//        model.addAttribute("reviewPage", reviewPage);
-//        model.addAttribute("nameMap", nameMap);
-//        model.addAttribute("activeMenu", "");
+            model.addAttribute("book", bookDetail);
+    //        model.addAttribute("reviewContent", reviewPage.content());
+    //        model.addAttribute("reviewPage", reviewPage);
+    //        model.addAttribute("nameMap", nameMap);
+    //        model.addAttribute("activeMenu", "");
 
-        return "book/detail";
-    }
+            return "book/detail";
+        }
+
+
+
+        //도서 상세페이지
+        @GetMapping("/books/{id}")
+        public String bookDetailBySearch(@PathVariable("id") Long bookId, Model model){
+
+            BookDetailResponse bookDetail = bookService.findBookById(bookId);
+            model.addAttribute("book", bookDetail);
+
+            return "book/detail";
+        }
 }

--- a/src/main/java/com/nhnacademy/illuwa/book/controller/BookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/controller/BookController.java
@@ -37,7 +37,7 @@ public class BookController {
 //        return "book/book_info";
 //    }
 
-    @GetMapping("/books/{isbn}")
+    @GetMapping("/books/isbn/{isbn}")
     public String bookDetail(@PathVariable("isbn") String isbn, Model model, HttpServletRequest request) {
         boolean isLoginUser = JwtCookieUtil.checkAccessToken(request);
 

--- a/src/main/java/com/nhnacademy/illuwa/book/service/BookService.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/service/BookService.java
@@ -22,6 +22,10 @@ public class BookService {
         return productServiceClient.findBookByIsbn(isbn);
     }
 
+    public BookDetailResponse findBookById(Long id){
+        return productServiceClient.findBookById(id);
+    }
+
 //    public List<SearchBookResponse> bookList() {
 //        return productServiceClient.findBooks();
 //    }

--- a/src/main/resources/static/js/book/booklist.js
+++ b/src/main/resources/static/js/book/booklist.js
@@ -35,7 +35,7 @@ document.querySelectorAll('.book-card').forEach(item => {
     item.addEventListener('click', () => {
         const bookIsbn = item.getAttribute('data-id');
         if (bookIsbn) {
-            window.location.href = `/books/${bookIsbn}`;
+            window.location.href = `/books/isbn/${bookIsbn}`;
         }
     });
 });

--- a/src/main/resources/static/js/home.js
+++ b/src/main/resources/static/js/home.js
@@ -12,7 +12,7 @@ document.querySelectorAll('.book-item').forEach(item => {
     item.addEventListener('click', () => {
         const bookIsbn = item.getAttribute('data-id');
         if (bookIsbn) {
-            window.location.href = `/books/${bookIsbn}`;
+            window.location.href = `/books/isbn/${bookIsbn}`;
         }
     });
 });

--- a/src/main/resources/templates/book/search_result.html
+++ b/src/main/resources/templates/book/search_result.html
@@ -4,7 +4,6 @@
       layout:decorate="~{layout/layout}">
 <head>
     <title>도서 검색 결과</title>
-    <link rel="stylesheet" th:href="@{/css/page/book/detail.css}" />
 </head>
 <body>
 <section layout:fragment="content">
@@ -20,7 +19,9 @@
 
 
     <div class="book-list">
-        <div class="book-card" th:each="book : ${books}">
+        <div class="book-card" th:each="book : ${books}"
+             th:data-id="${book.id}"
+             th:onclick="|window.location.href='/books/${book.id}'|">
             <img th:src="${book.thumbnailUrl}" alt="도서 이미지" width="150"/>
             <h3 th:text="${book.title}"></h3>
             <p th:text="'저자: ' + ${book.author}"></p>


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
### 도서 상세페이지 API 추가
	•	GET /books/{id} 형태의 도서 상세 조회 API 추가
### 도서 검색 결과 페이지에서 상세페이지로 이동
	•	검색 결과의 도서 카드를 클릭하면 ID 기반 경로(/books/{id})로 이동하도록 처리
### Feign Client 기능 확장
	•	도서 ID 기반으로 도서 상세정보를 조회하는 Feign API 메서드 추가

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #304 
