### PR TITLE
refactor: #307 휴면회원 api 수정

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/auth/client/InactiveVerificationServiceClient.java
+++ b/src/main/java/com/nhnacademy/illuwa/auth/client/InactiveVerificationServiceClient.java
@@ -11,9 +11,9 @@ public interface InactiveVerificationServiceClient {
     @PostMapping("/api/members/inactive/check-status")
     InactiveCheckResponse getInactiveMemberInfo(@RequestBody SendVerificationRequest request);
 
-    @PostMapping("/api/members/inactive/verification")
+    @PostMapping("/api/members/inactive/code")
     SendMessageResponse sendCode(SendVerificationRequest req);
 
-    @PostMapping("/api/members/inactive/verification/verify")
+    @PostMapping("/api/members/inactive/verification")
     VerifyCodeResponse verify(VerifyCodeRequest req);
 }

--- a/src/main/java/com/nhnacademy/illuwa/auth/controller/InactiveVerificationController.java
+++ b/src/main/java/com/nhnacademy/illuwa/auth/controller/InactiveVerificationController.java
@@ -13,19 +13,19 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/proxy/members/inactive/verification")
+@RequestMapping("/proxy/members/inactive")
 public class InactiveVerificationController {
 
     private final InactiveVerificationServiceClient inactiveVerificationServiceClient;
 
     /** 인증번호 발송 */
-    @PostMapping
+    @PostMapping("/code")
     public SendMessageResponse send(@RequestBody SendVerificationRequest req) {
         return inactiveVerificationServiceClient.sendCode(req);
     }
 
     /** 인증번호 검증 */
-    @PostMapping("/verify")
+    @PostMapping("/verification")
     public VerifyCodeResponse verify(@RequestBody VerifyCodeRequest req) {
         return inactiveVerificationServiceClient.verify(req);
     }

--- a/src/main/resources/static/js/auth/inactive-verification.js
+++ b/src/main/resources/static/js/auth/inactive-verification.js
@@ -6,8 +6,8 @@ const errorMessage = document.getElementById('errorMessage');
 const serverEmailInput = document.getElementById('serverEmail');
 
 const baseUrl = "";
-const SEND_API   = "/proxy/members/inactive/verification";
-const VERIFY_API = "/proxy/members/inactive/verification/verify";
+const SEND_API   = "/proxy/members/inactive/code";
+const VERIFY_API = "/proxy/members/inactive/verification";
 
 let timeLeft = 180;
 let timerInterval;


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
- user 쪽 api가 수정됨에 따라 front의 client api매핑 수정
    // 회원 휴면상태 체크
    @PostMapping("/api/members/inactive/check-status")
    InactiveCheckResponse getInactiveMemberInfo(@RequestBody SendVerificationRequest request);

    @PostMapping("/api/members/inactive/code")
    SendMessageResponse sendCode(SendVerificationRequest req);

    @PostMapping("/api/members/inactive/verification")
    VerifyCodeResponse verify(VerifyCodeRequest req)

- // js와 InactiveVerificationController에도 다음과 같이 이름 통일
- const SEND_API   = "/proxy/members/inactive/code";
const VERIFY_API = "/proxy/members/inactive/verification";

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #307 
