### PR TITLE
[FEAT] 상단 카테고리 섹션 spring cache 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,17 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+
+
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/com/nhnacademy/illuwa/FrontServerApplication.java
+++ b/src/main/java/com/nhnacademy/illuwa/FrontServerApplication.java
@@ -2,11 +2,13 @@ package com.nhnacademy.illuwa;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
 @SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 @EnableFeignClients
+@EnableCaching
 public class FrontServerApplication {
     public static void main(String[] args) {
         SpringApplication app = new SpringApplication(FrontServerApplication.class);

--- a/src/main/java/com/nhnacademy/illuwa/category/client/CategoryServiceClient.java
+++ b/src/main/java/com/nhnacademy/illuwa/category/client/CategoryServiceClient.java
@@ -34,9 +34,6 @@ public interface CategoryServiceClient {
             @RequestParam("sort") String sort
     );
 
-    @GetMapping("/api/categories/flat")
-    List<CategoryFlatResponse> getFlatCategories();
-
     @GetMapping("/api/categories/flat_paged")
     Page<CategoryFlatResponse> getFlatCategoriesPaged(@RequestParam("page") int page,
                                                       @RequestParam("size") int size,

--- a/src/main/java/com/nhnacademy/illuwa/category/service/CategoryService.java
+++ b/src/main/java/com/nhnacademy/illuwa/category/service/CategoryService.java
@@ -3,6 +3,7 @@ package com.nhnacademy.illuwa.category.service;
 import com.nhnacademy.illuwa.category.client.CategoryServiceClient;
 import com.nhnacademy.illuwa.category.dto.CategoryResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,6 +14,7 @@ public class CategoryService {
 
     private final CategoryServiceClient categoryClient;
 
+    @Cacheable(value = "categories")
     public List<CategoryResponse> getAllCategories() {
         return categoryClient.getAllCategories();
     }

--- a/src/main/java/com/nhnacademy/illuwa/common/controller_advice/CategoryControllerAdvice.java
+++ b/src/main/java/com/nhnacademy/illuwa/common/controller_advice/CategoryControllerAdvice.java
@@ -1,4 +1,4 @@
-package com.nhnacademy.illuwa.common.ca;
+package com.nhnacademy.illuwa.common.controller_advice;
 
 import com.nhnacademy.illuwa.category.dto.CategoryResponse;
 import com.nhnacademy.illuwa.category.service.CategoryService;

--- a/src/main/java/com/nhnacademy/illuwa/config/CacheConfig.java
+++ b/src/main/java/com/nhnacademy/illuwa/config/CacheConfig.java
@@ -1,0 +1,42 @@
+package com.nhnacademy.illuwa.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+public class CacheConfig {
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(createJsonSerializer()))
+                .entryTtl(Duration.ofHours(1));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig)
+                .build();
+    }
+
+
+    private GenericJackson2JsonRedisSerializer createJsonSerializer() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder().allowIfBaseType(Object.class).build(),
+                ObjectMapper.DefaultTyping.NON_FINAL
+        );
+        return new GenericJackson2JsonRedisSerializer(objectMapper);
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,9 @@ spring:
     name: front
   config:
     import: optional:configserver:https://book1lluwa.store/config/
+  data:
+    redis:
+      host: s4.java21.net
+      port: 6379
+      password: "*N2vya7H@muDTwdNMR!"
+      database: 300

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,3 @@ spring:
     name: front
   config:
     import: optional:configserver:https://book1lluwa.store/config/
-  data:
-    redis:
-      host: s4.java21.net
-      port: 6379
-      password: "*N2vya7H@muDTwdNMR!"
-      database: 300

--- a/src/main/resources/templates/book/detail.html
+++ b/src/main/resources/templates/book/detail.html
@@ -15,7 +15,6 @@
     <section class="main-content">
         <div class="container" th:if="${book != null}">
             <div class="book-detail">
-                <div class="book-images">
                     <div class="book-images">
                         <img th:if="${!#lists.isEmpty(book.imageUrls)}"
                              th:src="${book.imageUrls[0]}"
@@ -23,7 +22,6 @@
                              style="width: 200px; height: 300px; object-fit: cover;" />
                         <div class="image-thumbnails" id="thumbnails">
                         </div>
-                    </div>
                     </div>
                 </div>
             </div>

--- a/src/test/java/com/nhnacademy/illuwa/auth/controller/LoginControllerTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/auth/controller/LoginControllerTest.java
@@ -1,8 +1,6 @@
 package com.nhnacademy.illuwa.auth.controller;
 
-import com.nhnacademy.illuwa.common.ca.CategoryControllerAdvice;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import com.nhnacademy.illuwa.common.controller_advice.CategoryControllerAdvice;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -15,8 +13,6 @@ import wiremock.org.eclipse.jetty.security.LoginService;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 @WebMvcTest(controllers = LoginController.class,
         excludeFilters = {

--- a/src/test/java/com/nhnacademy/illuwa/cart/controller/CartControllerTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/cart/controller/CartControllerTest.java
@@ -5,8 +5,7 @@ import com.nhnacademy.illuwa.cart.dto.BookCartRequest;
 import com.nhnacademy.illuwa.cart.dto.BookCartResponse;
 import com.nhnacademy.illuwa.cart.dto.CartResponse;
 import com.nhnacademy.illuwa.cart.service.CartService;
-import com.nhnacademy.illuwa.common.ca.CategoryControllerAdvice;
-import com.nhnacademy.illuwa.member.controller.AdminMemberController;
+import com.nhnacademy.illuwa.common.controller_advice.CategoryControllerAdvice;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +15,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.web.servlet.MockMvc;
 

--- a/src/test/java/com/nhnacademy/illuwa/coupon/controller/AdminCouponControllerTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/coupon/controller/AdminCouponControllerTest.java
@@ -4,7 +4,7 @@ import com.nhnacademy.illuwa.admin.controller.AdminCouponController;
 import com.nhnacademy.illuwa.admin.controller.AdminPolicyController;
 import com.nhnacademy.illuwa.book.dto.BookDetailResponse;
 import com.nhnacademy.illuwa.book.service.BookService;
-import com.nhnacademy.illuwa.common.ca.CategoryControllerAdvice;
+import com.nhnacademy.illuwa.common.controller_advice.CategoryControllerAdvice;
 import com.nhnacademy.illuwa.coupon.dto.coupon.CouponForm;
 import com.nhnacademy.illuwa.coupon.dto.coupon.CouponResponse;
 import com.nhnacademy.illuwa.coupon.dto.coupon.CouponUpdateRequest;

--- a/src/test/java/com/nhnacademy/illuwa/coupon/controller/AdminCouponPolicyControllerTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/coupon/controller/AdminCouponPolicyControllerTest.java
@@ -1,7 +1,7 @@
 package com.nhnacademy.illuwa.coupon.controller;
 
 import com.nhnacademy.illuwa.admin.controller.AdminPolicyController;
-import com.nhnacademy.illuwa.common.ca.CategoryControllerAdvice;
+import com.nhnacademy.illuwa.common.controller_advice.CategoryControllerAdvice;
 import com.nhnacademy.illuwa.coupon.dto.couponPolicy.CouponPolicyFrom;
 import com.nhnacademy.illuwa.coupon.dto.couponPolicy.CouponPolicyResponse;
 import com.nhnacademy.illuwa.coupon.dto.couponPolicy.CouponPolicyUpdateRequest;
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = AdminPolicyController.class,
-        excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {CategoryControllerAdvice.class})})
+        excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {com.nhnacademy.illuwa.common.controller_advice.CategoryControllerAdvice.class})})
 
 @AutoConfigureMockMvc(addFilters = false)
 class AdminCouponPolicyControllerTest {

--- a/src/test/java/com/nhnacademy/illuwa/member/controller/AdminMemberControllerTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/member/controller/AdminMemberControllerTest.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.illuwa.member.controller;
 
-import com.nhnacademy.illuwa.common.ca.CategoryControllerAdvice;
+import com.nhnacademy.illuwa.common.controller_advice.CategoryControllerAdvice;
 import com.nhnacademy.illuwa.grade.enums.GradeName;
 import com.nhnacademy.illuwa.member.service.AdminMemberService;
 import com.nhnacademy.illuwa.common.dto.PageResponse;

--- a/src/test/java/com/nhnacademy/illuwa/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/member/controller/MemberControllerTest.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.illuwa.member.controller;
 
-import com.nhnacademy.illuwa.common.ca.CategoryControllerAdvice;
+import com.nhnacademy.illuwa.common.controller_advice.CategoryControllerAdvice;
 import com.nhnacademy.illuwa.common.exception.BackendApiException;
 import com.nhnacademy.illuwa.member.dto.MemberResponse;
 import com.nhnacademy.illuwa.member.dto.MemberUpdateRequest;

--- a/src/test/java/com/nhnacademy/illuwa/member/controller/MyPageControllerTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/member/controller/MyPageControllerTest.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.illuwa.member.controller;
 
-import com.nhnacademy.illuwa.common.ca.CategoryControllerAdvice;
+import com.nhnacademy.illuwa.common.controller_advice.CategoryControllerAdvice;
 import com.nhnacademy.illuwa.member.dto.MemberResponse;
 import com.nhnacademy.illuwa.member.enums.Role;
 import com.nhnacademy.illuwa.member.enums.Status;

--- a/src/test/java/com/nhnacademy/illuwa/memberaddress/controller/MemberAddressControllerTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/memberaddress/controller/MemberAddressControllerTest.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.illuwa.memberaddress.controller;
 
-import com.nhnacademy.illuwa.common.ca.CategoryControllerAdvice;
+import com.nhnacademy.illuwa.common.controller_advice.CategoryControllerAdvice;
 import com.nhnacademy.illuwa.common.dto.PageResponse;
 import com.nhnacademy.illuwa.memberaddress.client.MemberAddressServiceClient;
 import com.nhnacademy.illuwa.memberaddress.dto.MemberAddressRequest;


### PR DESCRIPTION
## 📝작업 내용
### 매 페이지 이동마다 불러왔던 category 데이터를  redis를 활용하여 cache 데이터로 저장해서 개선
	•	@EnableCaching 어노테이션 추가
	•	CacheConfig 생성 및 Redis 직렬화 설정 (GenericJackson2JsonRedisSerializer)
	•	CategoryService에 @Cacheable("categories") 적용
	•	application.yml에 Redis 설정 추가 후, config-repo로 이동
	•	ControllerAdvice 패키지 정리 및 경로 재정리
	•	사용되지 않는 카테고리 API 제거
	•	book-detail.html 중첩 <div> 태그 구조 수정

## 💬리뷰 요구사항(선택)
## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #375 
