### PR TITLE
[REFACTOR] API 경로 변경

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-httpclient</artifactId>
+        </dependency>
+
+
+        <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-commons</artifactId>
         </dependency>

--- a/src/main/java/com/nhnacademy/illuwa/admin/controller/AdminBookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/admin/controller/AdminBookController.java
@@ -140,7 +140,7 @@ public class AdminBookController {
 
     // -> 도서 수정 페이지
     @GetMapping("/{id}/form")
-    public String updateBookForm(@PathVariable String id, Model model) {
+    public String updateBookForm(@PathVariable Long id, Model model) {
         BookDetailWithExtraInfoResponse book = productServiceClient.getBookDetailWithExtraInfo(id);
         List<CategoryResponse> categoryTree = productServiceClient.getCategoryTree();
 

--- a/src/main/java/com/nhnacademy/illuwa/book/client/ProductServiceClient.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/client/ProductServiceClient.java
@@ -23,7 +23,7 @@ public interface ProductServiceClient {
     BookDetailResponse findBookByIsbn(@PathVariable String isbn);
 
     // 도서 검색(외부 API) - ISBN
-    @GetMapping("/api/books/external/isbn/{isbn}")
+    @GetMapping("/api/external-books/isbn/{isbn}")
     BookExternalResponse findBookByApi(@PathVariable String isbn);
 
     // 인기 도서 목록

--- a/src/main/java/com/nhnacademy/illuwa/book/client/ProductServiceClient.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/client/ProductServiceClient.java
@@ -35,7 +35,7 @@ public interface ProductServiceClient {
     List<BookDetailResponse> getRegisteredBook();
 
     //페이징 처리 도서목록
-    @GetMapping("/api/books/paged")
+    @GetMapping("/api/books")
     Page<BookDetailResponse> getRegisteredBookPaged(
             @RequestParam("page") int page,
             @RequestParam("size") int size,
@@ -70,19 +70,14 @@ public interface ProductServiceClient {
     @DeleteMapping("/api/admin/books/{id}")
     void deleteBook(@PathVariable Long id);
 
-
     // 도서 수정
-    @PostMapping("/api/admin/books/{id}/update")
+    @PatchMapping("/api/admin/books/{id}")
     void updateBook(@PathVariable("id") Long id, @RequestBody BookUpdateRequest request);
 
     // 도서 부가정보 포함된 도서 정보
     @GetMapping("/api/admin/books/{id}/detail")
-    BookDetailWithExtraInfoResponse getBookDetailWithExtraInfo(@PathVariable String id);
+    BookDetailWithExtraInfoResponse getBookDetailWithExtraInfo(@PathVariable Long id);
 
-
-    // 등록된 도서 목록
-    @GetMapping("/api/books/search")
-    List<SearchBookResponse> findBooks();
 
 
     // 도서 부가정보 포함된 도서 목록

--- a/src/main/java/com/nhnacademy/illuwa/book/service/BookService.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/service/BookService.java
@@ -33,7 +33,7 @@ public class BookService {
 
         return response;
     }
-  
+
     public List<BookDetailResponse> getAllBooks() {
         return productServiceClient.getRegisteredBook();
     }
@@ -48,7 +48,7 @@ public class BookService {
 
     @Cacheable(value = "bestSellers")
     public List<BestSellerResponse> getBestSellers() {
-        log.info("cache에 인기도서 목록 존재X");
+        log.info("현재 캐시에 인기도서 목록 존재 X, 가져오는중...");
         return productServiceClient.getBestSeller();
     }
 

--- a/src/main/java/com/nhnacademy/illuwa/book/service/BookService.java
+++ b/src/main/java/com/nhnacademy/illuwa/book/service/BookService.java
@@ -3,15 +3,12 @@ package com.nhnacademy.illuwa.book.service;
 import com.nhnacademy.illuwa.book.client.ProductServiceClient;
 import com.nhnacademy.illuwa.book.dto.BestSellerResponse;
 import com.nhnacademy.illuwa.book.dto.BookDetailResponse;
-import com.nhnacademy.illuwa.book.dto.SearchBookResponse;
 import com.nhnacademy.illuwa.category.dto.CategoryResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 

--- a/src/main/java/com/nhnacademy/illuwa/category/service/CategoryService.java
+++ b/src/main/java/com/nhnacademy/illuwa/category/service/CategoryService.java
@@ -3,6 +3,7 @@ package com.nhnacademy.illuwa.category.service;
 import com.nhnacademy.illuwa.category.client.CategoryServiceClient;
 import com.nhnacademy.illuwa.category.dto.CategoryResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -10,12 +11,14 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CategoryService {
 
     private final CategoryServiceClient categoryClient;
 
     @Cacheable(value = "categories")
     public List<CategoryResponse> getAllCategories() {
+        log.info("현재 캐시에 저장된 카테고리 목록 존재 X, 가져오는중...");
         return categoryClient.getAllCategories();
     }
 }

--- a/src/main/java/com/nhnacademy/illuwa/config/FeignClientConfig.java
+++ b/src/main/java/com/nhnacademy/illuwa/config/FeignClientConfig.java
@@ -1,11 +1,13 @@
 package com.nhnacademy.illuwa.config;
 
+import feign.Client;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
 import org.springframework.cloud.openfeign.support.SpringEncoder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import feign.form.spring.SpringFormEncoder;
+import org.apache.http.impl.client.HttpClients;
 import feign.codec.Encoder;
 
 @Configuration
@@ -13,5 +15,10 @@ public class FeignClientConfig {
     @Bean
     public Encoder feignFormEncoder(ObjectFactory<HttpMessageConverters> messageConverters) {
         return new SpringFormEncoder(new SpringEncoder(messageConverters));
+    }
+
+    @Bean
+    public Client feignClient() {
+        return new feign.httpclient.ApacheHttpClient(HttpClients.createDefault());
     }
 }

--- a/src/test/java/com/nhnacademy/illuwa/book/client/ProductClientTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/book/client/ProductClientTest.java
@@ -229,18 +229,8 @@ public class ProductClientTest {
         detail.setId(5L); detail.setTitle("부가정보도서");
         stub("/api/admin/books/5/detail", detail);
 
-        BookDetailWithExtraInfoResponse result = client.getBookDetailWithExtraInfo("5");
+        BookDetailWithExtraInfoResponse result = client.getBookDetailWithExtraInfo(5L);
         assertThat(result.getTitle()).isEqualTo("부가정보도서");
-    }
-
-    @Test
-    void findBooks() throws Exception {
-        SearchBookResponse s = new SearchBookResponse();
-        s.setTitle("검색도서");
-        stubList("/api/books/search", List.of(s));
-
-        List<SearchBookResponse> result = client.findBooks();
-        assertThat(result.getFirst().getTitle()).isEqualTo("검색도서");
     }
 
     @Test


### PR DESCRIPTION
## 📝작업 내용
	•	feign-httpclient 의존성 추가 및 FeignClientConfig 설정 반영
	•	 캐시 데이터 존재 여부 확인 시 로그 출력 추가
	•	 id 타입을 String → Long으로 수정
	•	 도서 페이징 목록의 API 경로 수정
	•	 외부 API 도서 검색 endpoint 변경 (/external/isbn/{isbn} → /api/external-books/isbn/{isbn})
	•	 사용하지 않는 테스트 메서드 제거

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #
